### PR TITLE
Added two additional parameters in order to build to proper signature:

### DIFF
--- a/examples/mediafire-cli.py
+++ b/examples/mediafire-cli.py
@@ -152,14 +152,8 @@ def main():  # pylint: disable=too-many-statements
                         default=os.environ.get('MEDIAFIRE_EMAIL', None))
     parser.add_argument('--password', dest='password', required=False,
                         default=os.environ.get('MEDIAFIRE_PASSWORD', None))
-<<<<<<< HEAD
+
     parser.add_argument('--appid', dest='appid', required=False, default=APP_ID)
-=======
-    parser.add_argument('--appid', dest='appid', required=False,
-                        default=os.environ.get('MEDIAFIRE_APPID', None))
-    parser.add_argument('--apikey', dest='apikey', required=False,
-                        default=os.environ.get('MEDIAFIRE_API_KEY', None))
->>>>>>> 1faeb6737edaeb7c5050bb2b6b5b573d9f6e9cc3
 
     actions = parser.add_subparsers(title='Actions', dest='action')
     # http://bugs.python.org/issue9253#msg186387

--- a/examples/mediafire-cli.py
+++ b/examples/mediafire-cli.py
@@ -19,7 +19,6 @@ logging.basicConfig(format=LOG_FORMAT, level=logging.WARNING)
 
 APP_ID = '42511'
 
-
 logging.getLogger("mediafire.client").setLevel(logging.INFO)
 logging.getLogger(
     "requests.packages.urllib3.connectionpool").setLevel(logging.WARNING)
@@ -153,6 +152,7 @@ def main():  # pylint: disable=too-many-statements
                         default=os.environ.get('MEDIAFIRE_EMAIL', None))
     parser.add_argument('--password', dest='password', required=False,
                         default=os.environ.get('MEDIAFIRE_PASSWORD', None))
+    parser.add_argument('--appid', dest='appid', required=False, default=APP_ID)
 
     actions = parser.add_subparsers(title='Actions', dest='action')
     # http://bugs.python.org/issue9253#msg186387
@@ -248,8 +248,8 @@ def main():  # pylint: disable=too-many-statements
 
     client = MediaFireClient()
 
-    if args.email and args.password:
-        client.login(args.email, args.password, app_id=APP_ID)
+    if args.email and args.password and args.appid:
+        client.login(args.email, args.password, app_id=args.appid)
 
     router = {
         "file-upload": do_file_upload,

--- a/examples/mediafire-cli.py
+++ b/examples/mediafire-cli.py
@@ -255,13 +255,8 @@ def main():  # pylint: disable=too-many-statements
 
     client = MediaFireClient()
 
-<<<<<<< HEAD
     if args.email and args.password and args.appid:
         client.login(args.email, args.password, app_id=args.appid)
-=======
-    if args.email and args.password and args.appid and args.apikey:
-        client.login(args.email, args.password, app_id=args.appid, api_key=args.apikey)
->>>>>>> 1faeb6737edaeb7c5050bb2b6b5b573d9f6e9cc3
 
     router = {
         "file-upload": do_file_upload,


### PR DESCRIPTION
--appid = identify the application id instead of hard-coded
--apikey = user's API KEY in order to build the proper signature

Both parameters are mandatory.