### PR TITLE
Handle MD5 File Hashes

### DIFF
--- a/mediafire/client.py
+++ b/mediafire/client.py
@@ -538,7 +538,11 @@ class MediaFireClient(object):
             else:
                 out_fd = open(target, 'wb')
 
-            checksum = hashlib.sha256()
+            if len(resource['hash']) == 32:
+                checksum = hashlib.md5()
+            else:
+                checksum = hashlib.sha256()
+            
             for chunk in response.iter_content(chunk_size=4096):
                 if chunk:
                     out_fd.write(chunk)


### PR DESCRIPTION
It appears some files have MD5 file hashes, which causes comparison the sha256 and an error when the client tries to download them.  This should allow both sha256 and md5s to gracefully process.